### PR TITLE
Fix when we have multiple ANDs inside an OR.

### DIFF
--- a/lib/applyFilters.js
+++ b/lib/applyFilters.js
@@ -94,6 +94,8 @@ function getKeyName(opts, key) {
   return key;
 }
 
+// TODO - if the top level is an OR, it'll wrap the whole condition in parentheses.  We can change this later.
+
 // opts is a mapping to customize renders.
 // opts currently has two fields: columnFormatter and fields.
 // fields contains a mapping of field names to options.  The only supported
@@ -107,22 +109,25 @@ const applyFilters = (query, filters, opts, or) => {
   const filterApplier = wrap(query, opts);
   map(filters, (value, key) => {
     // and
-    if (key === 'AND') {
-      // eslint-disable-next-line func-names
-      filterApplier.and(function() {
-        value.forEach(x => {
-          applyFilters(this, x, opts);
+    const keyIsOr = key === 'OR';
+    if (keyIsOr || key === 'AND') {
+      const nextLevelOr = key === 'OR';
+      // Change the where depending on what the previous level said.
+      if (or) {
+        // eslint-disable-next-line func-names
+        filterApplier.or(function() {
+          value.forEach(x => {
+            applyFilters(this, x, opts, nextLevelOr);
+          });
         });
-      });
-    }
-    // or
-    else if (key === 'OR') {
-      // eslint-disable-next-line func-names
-      filterApplier.or(function() {
-        value.forEach(x => {
-          applyFilters(this, x, opts, true);
+      } else {
+        // eslint-disable-next-line func-names
+        filterApplier.and(function() {
+          value.forEach(x => {
+            applyFilters(this, x, opts, nextLevelOr);
+          });
         });
-      });
+      }
     } else {
       map(value, (opValue, op) => {
         switch (op) {


### PR DESCRIPTION
The filtering code is broken when we want to nest multiple ANDs inside an OR.  The previous code just wiped out all of the AND/ORs to ANDs.

Here is an example filter;
filters={"OR":[{"ad_group_content_target_id":{"lt":23106}},{"AND":[{"ad_group_content_target_id":{"is":23106},"id":{"lt":"23106"}}]}]}